### PR TITLE
Refactor bet function in bot.ts to include a balance checker

### DIFF
--- a/bot.ts
+++ b/bot.ts
@@ -106,6 +106,14 @@ const bet = async (props: {
     process.exit();
   }
 
+  const balance = await getBalance();
+  const bnbBalance = parseFloat(balance);
+
+  if (bnbBalance < props.betAmount * 3) {
+    console.log("❌ Insufficient balance to place bet. Stopping the process.");
+    process.exit();
+  }
+
   await strategy({
     minAcurracy: CONFIG.THRESHOLD,
     onBetUp: async ({ buyPercentage }) => {


### PR DESCRIPTION
This pull request introduces a balance checker in the `bet` function of `bot.ts`. The `bet` function has been refactored to include a check that verifies if the balance in BNB is less than 3 times the `betAmount`. If the balance is insufficient, the process will stop, preventing the bot from placing bets when there is not enough balance available.

This enhancement ensures that the bot operates within the specified balance limits and avoids placing bets that could potentially result in an insufficient balance.